### PR TITLE
set worker's home directory

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -34,7 +34,7 @@ ENV PORT=8080
 EXPOSE 8080
 
 # Prepare a non-root user
-RUN adduser --system worker
+RUN adduser --system --home /home/worker worker
 WORKDIR /home/worker/app
 
 RUN mkdir local_data; chown worker local_data


### PR DESCRIPTION
some package depends on home directory to store cache data.  If don't set, the home directory will point to /nonexistent, then those packages may show permission deny warning. It also prevents vs-code to attach to the container.