### PR TITLE
Postprocessors

### DIFF
--- a/private_gpt/components/vector_store/vector_store_component.py
+++ b/private_gpt/components/vector_store/vector_store_component.py
@@ -130,12 +130,12 @@ class VectorStoreComponent:
         self,
         index: VectorStoreIndex,
         context_filter: ContextFilter | None = None,
-        similarity_top_k: int = 2,
+        sim_top_k = settings.rag.similarity_top_k,
     ) -> VectorIndexRetriever:
         # This way we support qdrant (using doc_ids) and the rest (using filters)
         return VectorIndexRetriever(
             index=index,
-            similarity_top_k=similarity_top_k,
+            similarity_top_k=sim_top_k,
             doc_ids=context_filter.docs_ids if context_filter else None,
             filters=(
                 _doc_id_metadata_filter(context_filter)

--- a/private_gpt/server/chat/chat_service.py
+++ b/private_gpt/server/chat/chat_service.py
@@ -118,7 +118,7 @@ class ChatService:
                 node_postprocessors=[
                     MetadataReplacementPostProcessor(target_metadata_key="window"),
                     SimilarityPostprocessor(
-                        similarity_cutoff=settings.llm.similarity_value
+                        similarity_cutoff=settings.rag.similarity_value
                     ),
                 ],
             )

--- a/private_gpt/server/chat/chat_service.py
+++ b/private_gpt/server/chat/chat_service.py
@@ -9,7 +9,6 @@ from llama_index.core.indices import VectorStoreIndex
 from llama_index.core.indices.postprocessor import MetadataReplacementPostProcessor
 from llama_index.core.llms import ChatMessage, MessageRole
 from llama_index.core.postprocessor import (
-    KeywordNodePostprocessor,
     SimilarityPostprocessor,
 )
 from llama_index.core.storage import StorageContext
@@ -107,38 +106,17 @@ class ChatService:
             vector_index_retriever = self.vector_store_component.get_retriever(
                 index=self.index, context_filter=context_filter
             )
-
-            # To use the keyword search, you must install spacy:
-            # pip install spacy
-            if settings().llm.keywords_include or settings().llm.keywords_exclude:
-                return ContextChatEngine.from_defaults(
-                    system_prompt=system_prompt,
-                    retriever=vector_index_retriever,
-                    llm=self.llm_component.llm,  # Takes no effect at the moment
-                    node_postprocessors=[
-                        MetadataReplacementPostProcessor(target_metadata_key="window"),
-                        SimilarityPostprocessor(
-                            similarity_cutoff=settings().llm.similarity_value
-                        ),
-                        KeywordNodePostprocessor(
-                            required_keywords=settings().llm.keywords_include,
-                            exclude_keywords=settings().llm.keywords_exclude,
-                        ),
-                    ],
-                )
-            else:
-                return ContextChatEngine.from_defaults(
-                    system_prompt=system_prompt,
-                    retriever=vector_index_retriever,
-                    llm=self.llm_component.llm,  # Takes no effect at the moment
-                    node_postprocessors=[
-                        MetadataReplacementPostProcessor(target_metadata_key="window"),
-                        SimilarityPostprocessor(
-                            similarity_cutoff=settings().llm.similarity_value
-                        ),
-                    ],
-                )
-
+            return ContextChatEngine.from_defaults(
+                system_prompt=system_prompt,
+                retriever=vector_index_retriever,
+                llm=self.llm_component.llm,  # Takes no effect at the moment
+                node_postprocessors=[
+                    MetadataReplacementPostProcessor(target_metadata_key="window"),
+                    SimilarityPostprocessor(
+                        similarity_cutoff=settings().llm.similarity_value
+                    ),
+                ],
+            )
         else:
             return SimpleChatEngine.from_defaults(
                 system_prompt=system_prompt,

--- a/private_gpt/server/chat/chat_service.py
+++ b/private_gpt/server/chat/chat_service.py
@@ -23,7 +23,7 @@ from private_gpt.components.vector_store.vector_store_component import (
 )
 from private_gpt.open_ai.extensions.context_filter import ContextFilter
 from private_gpt.server.chunks.chunks_service import Chunk
-from private_gpt.settings.settings import settings
+from private_gpt.settings.settings import Settings
 
 
 class Completion(BaseModel):
@@ -72,14 +72,18 @@ class ChatEngineInput:
 
 @singleton
 class ChatService:
+    settings: Settings
+
     @inject
     def __init__(
         self,
+        settings: Settings,
         llm_component: LLMComponent,
         vector_store_component: VectorStoreComponent,
         embedding_component: EmbeddingComponent,
         node_store_component: NodeStoreComponent,
     ) -> None:
+        self.settings = settings
         self.llm_component = llm_component
         self.embedding_component = embedding_component
         self.vector_store_component = vector_store_component
@@ -102,6 +106,7 @@ class ChatService:
         use_context: bool = False,
         context_filter: ContextFilter | None = None,
     ) -> BaseChatEngine:
+        settings = self.settings
         if use_context:
             vector_index_retriever = self.vector_store_component.get_retriever(
                 index=self.index, context_filter=context_filter
@@ -113,7 +118,7 @@ class ChatService:
                 node_postprocessors=[
                     MetadataReplacementPostProcessor(target_metadata_key="window"),
                     SimilarityPostprocessor(
-                        similarity_cutoff=settings().llm.similarity_value
+                        similarity_cutoff=settings.llm.similarity_value
                     ),
                 ],
             )

--- a/private_gpt/server/chat/chat_service.py
+++ b/private_gpt/server/chat/chat_service.py
@@ -7,9 +7,11 @@ from llama_index.core.chat_engine.types import (
 )
 from llama_index.core.indices import VectorStoreIndex
 from llama_index.core.indices.postprocessor import MetadataReplacementPostProcessor
-from llama_index.core.postprocessor import SimilarityPostprocessor
-from llama_index.core.postprocessor import KeywordNodePostprocessor
 from llama_index.core.llms import ChatMessage, MessageRole
+from llama_index.core.postprocessor import (
+    KeywordNodePostprocessor,
+    SimilarityPostprocessor,
+)
 from llama_index.core.storage import StorageContext
 from llama_index.core.types import TokenGen
 from pydantic import BaseModel
@@ -23,6 +25,7 @@ from private_gpt.components.vector_store.vector_store_component import (
 from private_gpt.open_ai.extensions.context_filter import ContextFilter
 from private_gpt.server.chunks.chunks_service import Chunk
 from private_gpt.settings.settings import settings
+
 
 class Completion(BaseModel):
     response: str
@@ -105,7 +108,7 @@ class ChatService:
                 index=self.index, context_filter=context_filter
             )
 
-            #To use the keyword search, you must install spacy:
+            # To use the keyword search, you must install spacy:
             # pip install spacy
             if settings().llm.keywords_include or settings().llm.keywords_exclude:
                 return ContextChatEngine.from_defaults(
@@ -114,8 +117,13 @@ class ChatService:
                     llm=self.llm_component.llm,  # Takes no effect at the moment
                     node_postprocessors=[
                         MetadataReplacementPostProcessor(target_metadata_key="window"),
-                        SimilarityPostprocessor(similarity_cutoff=settings().llm.similarity_value),
-                        KeywordNodePostprocessor(required_keywords=settings().llm.keywords_include, exclude_keywords=settings().llm.keywords_exclude),
+                        SimilarityPostprocessor(
+                            similarity_cutoff=settings().llm.similarity_value
+                        ),
+                        KeywordNodePostprocessor(
+                            required_keywords=settings().llm.keywords_include,
+                            exclude_keywords=settings().llm.keywords_exclude,
+                        ),
                     ],
                 )
             else:
@@ -125,7 +133,9 @@ class ChatService:
                     llm=self.llm_component.llm,  # Takes no effect at the moment
                     node_postprocessors=[
                         MetadataReplacementPostProcessor(target_metadata_key="window"),
-                        SimilarityPostprocessor(similarity_cutoff=settings().llm.similarity_value),
+                        SimilarityPostprocessor(
+                            similarity_cutoff=settings().llm.similarity_value
+                        ),
                     ],
                 )
 

--- a/private_gpt/server/chat/chat_service.py
+++ b/private_gpt/server/chat/chat_service.py
@@ -7,11 +7,9 @@ from llama_index.core.chat_engine.types import (
 )
 from llama_index.core.indices import VectorStoreIndex
 from llama_index.core.indices.postprocessor import MetadataReplacementPostProcessor
+from llama_index.core.postprocessor import SimilarityPostprocessor
+from llama_index.core.postprocessor import KeywordNodePostprocessor
 from llama_index.core.llms import ChatMessage, MessageRole
-from llama_index.core.postprocessor import (
-    KeywordNodePostprocessor,
-    SimilarityPostprocessor,
-)
 from llama_index.core.storage import StorageContext
 from llama_index.core.types import TokenGen
 from pydantic import BaseModel
@@ -25,7 +23,6 @@ from private_gpt.components.vector_store.vector_store_component import (
 from private_gpt.open_ai.extensions.context_filter import ContextFilter
 from private_gpt.server.chunks.chunks_service import Chunk
 from private_gpt.settings.settings import settings
-
 
 class Completion(BaseModel):
     response: str
@@ -107,45 +104,31 @@ class ChatService:
             vector_index_retriever = self.vector_store_component.get_retriever(
                 index=self.index, context_filter=context_filter
             )
-            # Initialize node_postporcessors
-            node_postprocessors_tmp: list[
-                MetadataReplacementPostProcessor
-                | SimilarityPostprocessor
-                | KeywordNodePostprocessor
-            ]
-            node_postprocessors_tmp = [
-                MetadataReplacementPostProcessor(target_metadata_key="window"),
-            ]
-            # If similarity value is set, use it.  If not, dont add it
-            if settings().llm.similarity_value is not None:
-                node_postprocessors_tmp.append(
-                    SimilarityPostprocessor(
-                        similarity_cutoff=settings().llm.similarity_value
-                    )
-                )
 
-            # If similarity value is set, use it.  If not, dont add it
-            # if settings().llm.keywords_include is not empty or
-            # settings().llm.keywords_exclude is not empty
+            #To use the keyword search, you must install spacy:
+            # pip install spacy
             if settings().llm.keywords_include or settings().llm.keywords_exclude:
-                node_postprocessors_tmp.append(
-                    KeywordNodePostprocessor(
-                        required_keywords=settings().llm.keywords_include,
-                        exclude_keywords=settings().llm.keywords_exclude,
-                    )
+                return ContextChatEngine.from_defaults(
+                    system_prompt=system_prompt,
+                    retriever=vector_index_retriever,
+                    llm=self.llm_component.llm,  # Takes no effect at the moment
+                    node_postprocessors=[
+                        MetadataReplacementPostProcessor(target_metadata_key="window"),
+                        SimilarityPostprocessor(similarity_cutoff=settings().llm.similarity_value),
+                        KeywordNodePostprocessor(required_keywords=settings().llm.keywords_include, exclude_keywords=settings().llm.keywords_exclude),
+                    ],
+                )
+            else:
+                return ContextChatEngine.from_defaults(
+                    system_prompt=system_prompt,
+                    retriever=vector_index_retriever,
+                    llm=self.llm_component.llm,  # Takes no effect at the moment
+                    node_postprocessors=[
+                        MetadataReplacementPostProcessor(target_metadata_key="window"),
+                        SimilarityPostprocessor(similarity_cutoff=settings().llm.similarity_value),
+                    ],
                 )
 
-            return ContextChatEngine.from_defaults(
-                system_prompt=system_prompt,
-                retriever=vector_index_retriever,
-                llm=self.llm_component.llm,  # Takes no effect at the moment
-                node_postprocessors=[
-                    MetadataReplacementPostProcessor(target_metadata_key="window"),
-                    SimilarityPostprocessor(
-                        similarity_cutoff=settings().llm.similarity_value
-                    ),
-                ],
-            )
         else:
             return SimpleChatEngine.from_defaults(
                 system_prompt=system_prompt,

--- a/private_gpt/settings/settings.py
+++ b/private_gpt/settings/settings.py
@@ -102,6 +102,18 @@ class LLMSettings(BaseModel):
         0.1,
         description="The temperature of the model. Increasing the temperature will make the model answer more creatively. A value of 0.1 would be more factual.",
     )
+    similarity_value: float = Field(
+        None,
+        description="If set, any documents retrieved from the RAG must meet a certain score. Acceptable values are between 0 and 1.",
+    )
+    keywords_include: list[str] = Field(
+        [],
+        description="If set, any documents retrieved from the RAG Must include this keyword",
+    )
+    keywords_exclude: list[str] = Field(
+        [],
+        description="If set, any documents retrieved from the RAG Must exclude this keyword",
+    )
 
 
 class VectorstoreSettings(BaseModel):
@@ -122,7 +134,6 @@ class LlamaCPPSettings(BaseModel):
             "`llama2` is the historic behaviour. `default` might work better with your custom models."
         ),
     )
-
     tfs_z: float = Field(
         1.0,
         description="Tail free sampling is used to reduce the impact of less probable tokens from the output. A higher value (e.g., 2.0) will reduce the impact more, while a value of 1.0 disables this setting.",

--- a/private_gpt/settings/settings.py
+++ b/private_gpt/settings/settings.py
@@ -107,6 +107,7 @@ class LLMSettings(BaseModel):
         description="If set, any documents retrieved from the RAG must meet a certain score. Acceptable values are between 0 and 1.",
     )
 
+
 class RagSettings(BaseModel):
     similarity_value: float = Field(
         None,
@@ -352,7 +353,6 @@ class Settings(BaseModel):
     data: DataSettings
     ui: UISettings
     llm: LLMSettings
-    rag: RagSettings
     embedding: EmbeddingSettings
     llamacpp: LlamaCPPSettings
     huggingface: HuggingFaceSettings
@@ -362,6 +362,7 @@ class Settings(BaseModel):
     vectorstore: VectorstoreSettings
     qdrant: QdrantSettings | None = None
     pgvector: PGVectorSettings | None = None
+    rag: RagSettings
 
 
 """

--- a/private_gpt/settings/settings.py
+++ b/private_gpt/settings/settings.py
@@ -108,6 +108,10 @@ class RagSettings(BaseModel):
         None,
         description="If set, any documents retrieved from the RAG must meet a certain score. Acceptable values are between 0 and 1.",
     )
+    similarity_top_k: int = Field(
+        2,
+        description="An integer that specifies the number of documents to use when searching the RAG database",
+    )
 
 
 class VectorstoreSettings(BaseModel):

--- a/private_gpt/settings/settings.py
+++ b/private_gpt/settings/settings.py
@@ -107,6 +107,12 @@ class LLMSettings(BaseModel):
         description="If set, any documents retrieved from the RAG must meet a certain score. Acceptable values are between 0 and 1.",
     )
 
+class RagSettings(BaseModel):
+    similarity_value: float = Field(
+        None,
+        description="If set, any documents retrieved from the RAG must meet a certain score. Acceptable values are between 0 and 1.",
+    )
+
 
 class VectorstoreSettings(BaseModel):
     database: Literal["chroma", "qdrant", "pgvector"]
@@ -346,6 +352,7 @@ class Settings(BaseModel):
     data: DataSettings
     ui: UISettings
     llm: LLMSettings
+    rag: RagSettings
     embedding: EmbeddingSettings
     llamacpp: LlamaCPPSettings
     huggingface: HuggingFaceSettings

--- a/private_gpt/settings/settings.py
+++ b/private_gpt/settings/settings.py
@@ -106,14 +106,6 @@ class LLMSettings(BaseModel):
         None,
         description="If set, any documents retrieved from the RAG must meet a certain score. Acceptable values are between 0 and 1.",
     )
-    keywords_include: list[str] = Field(
-        [],
-        description="If set, any documents retrieved from the RAG Must include this keyword",
-    )
-    keywords_exclude: list[str] = Field(
-        [],
-        description="If set, any documents retrieved from the RAG Must exclude this keyword",
-    )
 
 
 class VectorstoreSettings(BaseModel):

--- a/private_gpt/settings/settings.py
+++ b/private_gpt/settings/settings.py
@@ -102,14 +102,9 @@ class LLMSettings(BaseModel):
         0.1,
         description="The temperature of the model. Increasing the temperature will make the model answer more creatively. A value of 0.1 would be more factual.",
     )
-    similarity_value: float = Field(
-        None,
-        description="If set, any documents retrieved from the RAG must meet a certain score. Acceptable values are between 0 and 1.",
-    )
-
 
 class RagSettings(BaseModel):
-    similarity_value: float = Field(
+    similarity_value: float | None = Field(
         None,
         description="If set, any documents retrieved from the RAG must meet a certain score. Acceptable values are between 0 and 1.",
     )

--- a/settings-local.yaml
+++ b/settings-local.yaml
@@ -24,3 +24,6 @@ vectorstore:
 
 qdrant:
   path: local_data/private_gpt/qdrant
+
+rag:
+  similarity_value: # Leave empty to not use.  Otherwise set between 0 and 1.  This value checks for how well sources match your context.

--- a/settings.yaml
+++ b/settings.yaml
@@ -40,6 +40,9 @@ llm:
   max_new_tokens: 512
   context_window: 3900
   temperature: 0.1      # The temperature of the model. Increasing the temperature will make the model answer more creatively. A value of 0.1 would be more factual. (Default: 0.1)
+  #similarity_value: 0.4    #If set, any documents retrieved from the RAG must meet a certain score. Acceptable values are between 0 and 1.
+  #keywords_include: ["Apples","Bananas"] #Optional - requires spacy package: pip install spacy
+  #keywords_exclude: ["Pears","Mangos"]   #Optional - requires spacy package: pip install spacy
 
 llamacpp:
   prompt_style: "mistral"

--- a/settings.yaml
+++ b/settings.yaml
@@ -41,8 +41,6 @@ llm:
   context_window: 3900
   temperature: 0.1      # The temperature of the model. Increasing the temperature will make the model answer more creatively. A value of 0.1 would be more factual. (Default: 0.1)
   #similarity_value: 0.4    #If set, any documents retrieved from the RAG must meet a certain score. Acceptable values are between 0 and 1.
-  #keywords_include: ["Apples","Bananas"] #Optional - requires spacy package: pip install spacy
-  #keywords_exclude: ["Pears","Mangos"]   #Optional - requires spacy package: pip install spacy
 
 llamacpp:
   prompt_style: "mistral"

--- a/settings.yaml
+++ b/settings.yaml
@@ -40,7 +40,9 @@ llm:
   max_new_tokens: 512
   context_window: 3900
   temperature: 0.1      # The temperature of the model. Increasing the temperature will make the model answer more creatively. A value of 0.1 would be more factual. (Default: 0.1)
-  #similarity_value: 0.4    #If set, any documents retrieved from the RAG must meet a certain score. Acceptable values are between 0 and 1.
+
+rag:
+  #similarity_value: 0.4    #Optional - If set, any documents retrieved from the RAG must meet a certain score. Acceptable values are between 0 and 1.
 
 llamacpp:
   prompt_style: "mistral"

--- a/settings.yaml
+++ b/settings.yaml
@@ -41,7 +41,9 @@ llm:
   context_window: 3900
   temperature: 0.1      # The temperature of the model. Increasing the temperature will make the model answer more creatively. A value of 0.1 would be more factual. (Default: 0.1)
 
-rag:
+#
+# The rag settings are optional.  Only include if you know what you are doing.
+#rag:
   #similarity_value: 0.4    #Optional - If set, any documents retrieved from the RAG must meet a certain score. Acceptable values are between 0 and 1.
 
 llamacpp:

--- a/settings.yaml
+++ b/settings.yaml
@@ -41,10 +41,8 @@ llm:
   context_window: 3900
   temperature: 0.1      # The temperature of the model. Increasing the temperature will make the model answer more creatively. A value of 0.1 would be more factual. (Default: 0.1)
 
-#
-# The rag settings are optional.  Only include if you know what you are doing.
-#rag:
-  #similarity_value: 0.4    #Optional - If set, any documents retrieved from the RAG must meet a certain score. Acceptable values are between 0 and 1.
+rag:
+  similarity_value: # Leave empty to not use.  Otherwise set between 0 and 1.  This value checks for how well sources match your context.
 
 llamacpp:
   prompt_style: "mistral"


### PR DESCRIPTION
Added capability to use similarity match as well as keyword include/exclude.

```
            if settings().llm.keywords_include or settings().llm.keywords_exclude:
                return ContextChatEngine.from_defaults(
                    system_prompt=system_prompt,
                    retriever=vector_index_retriever,
                    llm=self.llm_component.llm,  # Takes no effect at the moment
                    node_postprocessors=[
                        MetadataReplacementPostProcessor(target_metadata_key="window"),
                        SimilarityPostprocessor(similarity_cutoff=settings().llm.similarity_value),
                        KeywordNodePostprocessor(required_keywords=settings().llm.keywords_include, exclude_keywords=settings().llm.keywords_exclude),
                    ],
                )
            else:
                return ContextChatEngine.from_defaults(
                    system_prompt=system_prompt,
                    retriever=vector_index_retriever,
                    llm=self.llm_component.llm,  # Takes no effect at the moment
                    node_postprocessors=[
                        MetadataReplacementPostProcessor(target_metadata_key="window"),
                        SimilarityPostprocessor(similarity_cutoff=settings().llm.similarity_value),
                    ],
                )
```
Looking at:
SimilarityPostprocessor(similarity_cutoff=settings().llm.similarity_value)

The default value is none and you can look at how llama_index handles this:
https://github.com/run-llama/llama_index/blob/d33b789de9635dcf19e02050c6a0487fcfeb30ad/llama-index-core/llama_index/core/postprocessor/node.py#L64

This class automatically ignores it if set to None:
```
sim_cutoff_exists = self.similarity_cutoff is not None
```


