### PR TITLE
Fixed docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,5 +10,4 @@ services:
     environment:
       PORT: 8080
       PGPT_PROFILES: docker
-      PGPT_MODE: local
-
+      PGPT_MODE: ollama

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,4 +10,4 @@ services:
     environment:
       PORT: 8080
       PGPT_PROFILES: docker
-      PGPT_MODE: ollama
+      PGPT_MODE: llamacpp


### PR DESCRIPTION
Make the compose work avoiding Pydantic error not recognizing local as proper mode.