### PR TITLE
Add nbconvert to poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,8 @@ pytest-cov = "^3"
 ruff = "^0"
 pytest-asyncio = "^0.21.1"
 types-pyyaml = "^6.0.12.12"
+nbconvert = ^7.16.2
+
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
The environment can't add notebook files in the UI without nbconvert.