### PR TITLE
Feat wipe qdrant

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -11,6 +11,7 @@ def wipe() -> None:
         "simple": wipe_simple,  # node store
         "chroma": wipe_chroma,  # vector store
         "postgres": wipe_postgres,  # node, index and vector store
+        "qdrant": wipe_qdrant, # vector store
     }
     for dbtype in ("nodestore", "vectorstore"):
         database = getattr(settings(), dbtype).database
@@ -93,9 +94,26 @@ def wipe_postgres(dbtype: str) -> None:
             conn.close()
 
 
-def wipe_chroma(dbtype: str):
+def wipe_chroma(dbtype: str) -> None:
     assert dbtype == "vectorstore"
     wipe_tree(str((local_data_path / "chroma_db").absolute()))
+
+
+def wipe_qdrant(dbtype: str) -> None:
+    assert dbtype == "vectorstore"
+    try:
+        from qdrant_client import QdrantClient  # type: ignore
+    except ImportError:
+        raise ImportError("Qdrant dependencies not found")
+    client = QdrantClient(
+                        **settings().qdrant.model_dump(exclude_none=True)
+                    )
+    collection_name = "make_this_parameterizable_per_api_call" # ?! see vector_store_component.py
+    try:
+        client.delete_collection(collection_name)
+        print("Collection dropped successfully.")
+    except Exception as e:
+        print("Error dropping collection:", e)
 
 
 if __name__ == "__main__":

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -11,7 +11,7 @@ def wipe() -> None:
         "simple": wipe_simple,  # node store
         "chroma": wipe_chroma,  # vector store
         "postgres": wipe_postgres,  # node, index and vector store
-        "qdrant": wipe_qdrant, # vector store
+        "qdrant": wipe_qdrant,  # vector store
     }
     for dbtype in ("nodestore", "vectorstore"):
         database = getattr(settings(), dbtype).database
@@ -104,11 +104,11 @@ def wipe_qdrant(dbtype: str) -> None:
     try:
         from qdrant_client import QdrantClient  # type: ignore
     except ImportError:
-        raise ImportError("Qdrant dependencies not found")
-    client = QdrantClient(
-                        **settings().qdrant.model_dump(exclude_none=True)
-                    )
-    collection_name = "make_this_parameterizable_per_api_call" # ?! see vector_store_component.py
+        raise ImportError("Qdrant dependencies not found") from None
+    client = QdrantClient(**settings().qdrant.model_dump(exclude_none=True))
+    collection_name = (
+        "make_this_parameterizable_per_api_call"  # ?! see vector_store_component.py
+    )
     try:
         client.delete_collection(collection_name)
         print("Collection dropped successfully.")


### PR DESCRIPTION
Add support for deleting the collection created in a `qdrant` vector datastore.
```
vectorstore:
  database: qdrant
```
I did not change the name of the store from ```make_this_parameterizable_per_api_call``` for upgrade compatibility.

This collection should be named something more appropriate.   I suggest ```data_embeddings```. This is how its named in the Postgres database.  Renaming this store will be a breaking upgrade for those who have ingested data.

### Test output
```
% ls local_data/private_gpt/qdrant/collection 
make_this_parameterizable_per_api_call
% PGPT_PROFILES=local make wipe
poetry run python scripts/utils.py wipe
20:31:23.378 [INFO    ] private_gpt.settings.settings_loader - Starting application with profiles=['default', 'local']
Collection dropped successfully.
% ls local_data/private_gpt/qdrant/collection
%
```
