### PR TITLE
Updated prompt_style to be moved to the main LLM settings and included various settings into the openailike mode.

### DIFF
--- a/private_gpt/components/llm/llm_component.py
+++ b/private_gpt/components/llm/llm_component.py
@@ -40,7 +40,7 @@ class LLMComponent:
                         "Local dependencies not found, install with `poetry install --extras llms-llama-cpp`"
                     ) from e
 
-                prompt_style = get_prompt_style(settings.llamacpp.prompt_style)
+                prompt_style = get_prompt_style(settings.llm.prompt_style)
                 settings_kwargs = {
                     "tfs_z": settings.llamacpp.tfs_z,  # ollama and llama-cpp
                     "top_k": settings.llamacpp.top_k,  # ollama and llama-cpp
@@ -98,15 +98,20 @@ class LLMComponent:
                     raise ImportError(
                         "OpenAILike dependencies not found, install with `poetry install --extras llms-openai-like`"
                     ) from e
-
+                prompt_style = get_prompt_style(settings.llm.prompt_style)
                 openai_settings = settings.openai
                 self.llm = OpenAILike(
                     api_base=openai_settings.api_base,
                     api_key=openai_settings.api_key,
                     model=openai_settings.model,
                     is_chat_model=True,
-                    max_tokens=None,
+                    max_tokens=settings.llm.max_new_tokens,
                     api_version="",
+                    temperature=settings.llm.temperature,
+                    context_window=settings.llm.context_window,
+                    max_new_tokens=settings.llm.max_new_tokens,
+                    messages_to_prompt=prompt_style.messages_to_prompt,
+                    completion_to_prompt=prompt_style.completion_to_prompt,
                 )
             case "ollama":
                 try:

--- a/private_gpt/settings/settings.py
+++ b/private_gpt/settings/settings.py
@@ -104,6 +104,17 @@ class LLMSettings(BaseModel):
         0.1,
         description="The temperature of the model. Increasing the temperature will make the model answer more creatively. A value of 0.1 would be more factual.",
     )
+    prompt_style: Literal["default", "llama2", "tag", "mistral", "chatml"] = Field(
+        "llama2",
+        description=(
+            "The prompt style to use for the chat engine. "
+            "If `default` - use the default prompt style from the llama_index. It should look like `role: message`.\n"
+            "If `llama2` - use the llama2 prompt style from the llama_index. Based on `<s>`, `[INST]` and `<<SYS>>`.\n"
+            "If `tag` - use the `tag` prompt style. It should look like `<|role|>: message`. \n"
+            "If `mistral` - use the `mistral prompt style. It shoudl look like <s>[INST] {System Prompt} [/INST]</s>[INST] { UserInstructions } [/INST]"
+            "`llama2` is the historic behaviour. `default` might work better with your custom models."
+        ),
+    )
 
 
 class VectorstoreSettings(BaseModel):

--- a/settings.yaml
+++ b/settings.yaml
@@ -36,6 +36,7 @@ ui:
 
 llm:
   mode: llamacpp
+  prompt_style: "mistral"
   # Should be matching the selected model
   max_new_tokens: 512
   context_window: 3900


### PR DESCRIPTION
I noticed, after trying new models and trying to implement new chat style templates, it did not seem to have an effect when using openailike.

I have moved the "prompt_style" under the LLM: section in the settings.yaml file as this should be able to be universally used across the various LLM modes.

However, since I am currently using VLLM to serve my model, I can test the other implementations.  I have only changed the existing llamacpp and openailike to use the prompt_style (It is not currently being used anywhere else).

I also noticed that when using openailike, that I would easily exceed my various token limits. I believe this was due to max_tokens being set to none, or unlimited.  I have changed this to use the "max_new_tokens" from the settings.yaml file.

I also included temperature, context_window,messages_to_prompt and completion_to_prompt values.



**In the future,** instead of hardcoding the different chat templates/styles, llama_index supports using .jinja formats:
https://github.com/vllm-project/vllm/tree/main/examples

https://github.com/chujiezheng/chat_templates/tree/main/chat_templates

Instead of changing the code, it would be more effective to have these templates in a directory, and to be able to reference them by their file name.  That way if you want a new template, you could easily drop it into a specific folder and reference the filename, instead of having to change code.  This allows that functionality to be dynamic without having to change anything within pgpt.  However I dont have a PR for this yet.