### PR TITLE
 Model Temperature editing enabled on UI

### DIFF
--- a/private_gpt/settings/settings.py
+++ b/private_gpt/settings/settings.py
@@ -151,6 +151,10 @@ class HuggingFaceSettings(BaseModel):
     embedding_hf_model_name: str = Field(
         description="Name of the HuggingFace model to use for embeddings"
     )
+    access_token: str = Field(
+        None,
+        description="Huggingface access token, required to download some models",
+    )
 
 
 class EmbeddingSettings(BaseModel):

--- a/private_gpt/settings/settings.py
+++ b/private_gpt/settings/settings.py
@@ -151,10 +151,6 @@ class HuggingFaceSettings(BaseModel):
     embedding_hf_model_name: str = Field(
         description="Name of the HuggingFace model to use for embeddings"
     )
-    access_token: str = Field(
-        None,
-        description="Huggingface access token, required to download some models",
-    )
 
 
 class EmbeddingSettings(BaseModel):
@@ -293,6 +289,9 @@ class UISettings(BaseModel):
     )
     delete_all_files_button_enabled: bool = Field(
         False, description="If the button to delete all files is enabled or not."
+    )
+    adjust_temperature_enabled: bool = Field(
+        False, description="If editing function of the Model temperature is enabled or not"
     )
 
 

--- a/private_gpt/ui/ui.py
+++ b/private_gpt/ui/ui.py
@@ -376,8 +376,8 @@ class PrivateGptUi:
                         label="Model Temperature",
                         interactive=True,
                         visible=settings().ui.adjust_temperature_enabled,
-                        minimum=0.1,
-                        maximum=1,
+                        minimum=0.05,
+                        maximum=0.95,
                     )
 
                     deselect_file_button.click(

--- a/private_gpt/ui/ui.py
+++ b/private_gpt/ui/ui.py
@@ -206,6 +206,10 @@ class PrivateGptUi:
         logger.info(f"Setting system prompt to: {system_prompt_input}")
         self._system_prompt = system_prompt_input
 
+    def _set_model_temperature(self, model_temperature_input: str) -> None:
+        logger.info(f"Setting Model Temperature to: {model_temperature_input}")
+        self._model_temperature = model_temperature_input
+
     def _set_current_mode(self, mode: str) -> Any:
         self.mode = mode
         self._set_system_prompt(self._get_default_system_prompt(mode))
@@ -367,6 +371,15 @@ class PrivateGptUi:
                         size="sm",
                         visible=settings().ui.delete_all_files_button_enabled,
                     )
+                    adjust_model_temperature = gr.components.Number(
+                        value=settings().llm.temperature,
+                        label="Model Temperature",
+                        interactive=True,
+                        visible=settings().ui.adjust_temperature_enabled,
+                        minimum=0.1,
+                        maximum=1,
+                    )
+
                     deselect_file_button.click(
                         self._deselect_selected_file,
                         outputs=[
@@ -416,6 +429,10 @@ class PrivateGptUi:
                     system_prompt_input.blur(
                         self._set_system_prompt,
                         inputs=system_prompt_input,
+                    )
+                    adjust_model_temperature.input(
+                        self._set_model_temperature,
+                        inputs=adjust_model_temperature,
                     )
 
                     def get_model_label() -> str | None:

--- a/settings.yaml
+++ b/settings.yaml
@@ -70,6 +70,7 @@ embedding:
 
 huggingface:
   embedding_hf_model_name: BAAI/bge-small-en-v1.5
+  access_token: ${HUGGINGFACE_TOKEN:}
 
 vectorstore:
   database: qdrant

--- a/settings.yaml
+++ b/settings.yaml
@@ -33,6 +33,7 @@ ui:
     the answer, just state the answer is not in the context provided.
   delete_file_button_enabled: true
   delete_all_files_button_enabled: true
+  adjust_temperature_enabled: true
 
 llm:
   mode: llamacpp
@@ -69,7 +70,6 @@ embedding:
 
 huggingface:
   embedding_hf_model_name: BAAI/bge-small-en-v1.5
-  access_token: ${HUGGINGFACE_TOKEN:}
 
 vectorstore:
   database: qdrant


### PR DESCRIPTION
Model Temperature editing enabled on UI. This option enables the user to "play" with the model´s spontaneity without having to restart the code every time. 
Visualization enabled from "settings.yaml". Range of Temperature goes from 0.05 to 0.95 since 0 and 1 are not possible values for this parameter. 
I didn´t add the rest of parameters (top_k, top_p, etc..)  as i belive it´d bee too much info in the UI. But I´m open to do it if you consider it´d be nice. 