### PR TITLE
Add customizable embedding model support for OpenAI API

### DIFF
--- a/private_gpt/components/embedding/embedding_component.py
+++ b/private_gpt/components/embedding/embedding_component.py
@@ -56,7 +56,10 @@ class EmbeddingComponent:
                     ) from e
 
                 openai_settings = settings.openai.api_key
-                self.embedding_model = OpenAIEmbedding(api_key=openai_settings)
+                self.embedding_model = OpenAIEmbedding(
+                    api_key=openai_settings,
+                    model=openai_settings.embedding_model,
+                )
             case "ollama":
                 try:
                     from llama_index.embeddings.ollama import (  # type: ignore

--- a/private_gpt/settings/settings.py
+++ b/private_gpt/settings/settings.py
@@ -201,6 +201,10 @@ class OpenAISettings(BaseModel):
         description="Base URL of OpenAI API. Example: 'https://api.openai.com/v1'.",
     )
     api_key: str
+    embedding_model: str = Field(
+        "text-embedding-ada-002",
+        description="OpenAI Model to use. Example: 'text-embedding-ada-002'.",
+    )
     model: str = Field(
         "gpt-3.5-turbo",
         description="OpenAI Model to use. Example: 'gpt-4'.",

--- a/settings-openai.yaml
+++ b/settings-openai.yaml
@@ -3,6 +3,7 @@ server:
 
 llm:
   mode: openai
+  embedding_model: text-embedding-ada-002
 
 embedding:
   mode: openai

--- a/settings.yaml
+++ b/settings.yaml
@@ -95,6 +95,7 @@ sagemaker:
 openai:
   api_key: ${OPENAI_API_KEY:}
   model: gpt-3.5-turbo
+  embedding_model: text-embedding-ada-002
 
 ollama:
   llm_model: llama2


### PR DESCRIPTION
This pull request enables the specification of embedding models in the OpenAI settings. Changes include updates to configuration files and the embedding component.

### Changes Made
- Modified `settings-openai.yaml` to accept `embedding_model` under the `llm` section.
- Updated `settings.yaml` to define `embedding_model` for the OpenAI service.
- Altered `embedding_component.py` in the `private_gpt` to initialize `OpenAIEmbedding` with a user-defined model.
- Added `embedding_model` field in `private_gpt/settings/settings.py` with a default value and description.


This enhancement allows for flexible selection of OpenAI embedding models, enhancing adaptability to various use cases.