### PR TITLE
fix(settings): enable cors by default

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -5,7 +5,7 @@ server:
   env_name: ${APP_ENV:prod}
   port: ${PORT:8001}
   cors:
-    enabled: false
+    enabled: true
     allow_origins: ["*"]
     allow_methods: ["*"]
     allow_headers: ["*"]


### PR DESCRIPTION
Enable cors by default but leave all origins, methods and headers so it will work when consuming pgpt directly in the new ts SDK