### PR TITLE
Dockerfile.external patches

### DIFF
--- a/Dockerfile.external
+++ b/Dockerfile.external
@@ -23,9 +23,11 @@ ENV PORT=8080
 EXPOSE 8080
 
 # Prepare a non-root user
-RUN adduser --system worker
+RUN adduser --group worker
+RUN adduser --ingroup worker worker
 WORKDIR /home/worker/app
 
+RUN chown worker /home/worker/app
 RUN mkdir local_data; chown worker local_data
 RUN mkdir models; chown worker models
 COPY --chown=worker --from=dependencies /home/worker/app/.venv/ .venv

--- a/Dockerfile.external-new
+++ b/Dockerfile.external-new
@@ -1,0 +1,39 @@
+FROM python:3.11.6-slim-bookworm as base
+
+# Install poetry
+RUN pip install pipx
+RUN python3 -m pipx ensurepath
+RUN pipx install poetry
+ENV PATH="/root/.local/bin:$PATH"
+ENV PATH=".venv/bin/:$PATH"
+
+# https://python-poetry.org/docs/configuration/#virtualenvsin-project
+ENV POETRY_VIRTUALENVS_IN_PROJECT=true
+
+FROM base as dependencies
+WORKDIR /home/worker/app
+COPY pyproject.toml poetry.lock ./
+
+RUN poetry install --extras "ui vector-stores-qdrant llms-ollama embeddings-ollama"
+
+FROM base as app
+
+ENV PYTHONUNBUFFERED=1
+ENV PORT=8080
+EXPOSE 8080
+
+# Prepare a non-root user
+RUN adduser --system worker
+WORKDIR /home/worker/app
+
+RUN mkdir local_data; chown worker local_data
+RUN mkdir models
+COPY --from=dependencies /home/worker/app/.venv/ .venv
+COPY private_gpt/ private_gpt
+COPY fern/ fern
+COPY *.yaml *.md ./
+COPY scripts/ scripts
+
+ENV PYTHONPATH="$PYTHONPATH:/private_gpt/"
+
+ENTRYPOINT python -m private_gpt


### PR DESCRIPTION
Fix Dockerfile.external:
Copy changes from Dockerfile.local 19 Apr 2024 947e737f300adf621d2261d527192f36f3387f8e

    fix: "no such group" error in Dockerfile

Added "RUN chown worker /home/worker/app" to fix runtime startup error mentioned here: https://github.com/zylon-ai/private-gpt/issues/1876#issuecomment-2138500112

Built and ran docker container from Dockerfile.external.  Tested with ollama server and docker compose.