### PR TITLE
fix: unify embedding models

### DIFF
--- a/fern/docs/pages/installation/troubleshooting.mdx
+++ b/fern/docs/pages/installation/troubleshooting.mdx
@@ -29,3 +29,21 @@ PrivateGPT uses the `AutoTokenizer` library to tokenize input text accurately. I
 2. **Set Access Token for Gated Models:**
    If you are using a gated model, ensure the `access_token` is set as mentioned in the previous section.
 This configuration ensures that PrivateGPT can download and use the correct tokenizer for the model you are working with.
+
+# Embedding dimensions mismatch
+If you encounter an error message like `Embedding dimensions mismatch`, it is likely due to the embedding model and
+current vector dimension mismatch. To resolve this issue, ensure that the model and the input data have the same vector dimensions.
+
+By default, PrivateGPT uses `nomic-embed-text` embeddings, which have a vector dimension of 768.
+If you are using a different embedding model, ensure that the vector dimensions match the model's output.
+
+<Callout intent = "warning">
+In version <= 0.6.0, the default embedding model was `BAAI/bge-small-en-v1.5` in `huggingface` setup.
+If you plan to reuse the old generated embeddings, you need to update the `settings.yaml` file to use the correct embedding model:
+```yaml
+huggingface:
+  embedding_hf_model_name: BAAI/bge-small-en-v1.5
+embedding:
+  embed_dim: 384
+```
+</Callout>

--- a/fern/docs/pages/installation/troubleshooting.mdx
+++ b/fern/docs/pages/installation/troubleshooting.mdx
@@ -38,7 +38,7 @@ By default, PrivateGPT uses `nomic-embed-text` embeddings, which have a vector d
 If you are using a different embedding model, ensure that the vector dimensions match the model's output.
 
 <Callout intent = "warning">
-In version <= 0.6.0, the default embedding model was `BAAI/bge-small-en-v1.5` in `huggingface` setup.
+In versions below to 0.6.0, the default embedding model was `BAAI/bge-small-en-v1.5` in `huggingface` setup.
 If you plan to reuse the old generated embeddings, you need to update the `settings.yaml` file to use the correct embedding model:
 ```yaml
 huggingface:

--- a/settings-docker.yaml
+++ b/settings-docker.yaml
@@ -13,7 +13,7 @@ llamacpp:
   llm_hf_model_file: ${PGPT_HF_MODEL_FILE:mistral-7b-instruct-v0.1.Q4_K_M.gguf}
 
 huggingface:
-  embedding_hf_model_name: ${PGPT_EMBEDDING_HF_MODEL_NAME:BAAI/bge-small-en-v1.5}
+  embedding_hf_model_name: ${PGPT_EMBEDDING_HF_MODEL_NAME:nomic-ai/nomic-embed-text-v1.5}
 
 sagemaker:
   llm_endpoint_name: ${PGPT_SAGEMAKER_LLM_ENDPOINT_NAME:}

--- a/settings-local.yaml
+++ b/settings-local.yaml
@@ -18,7 +18,7 @@ embedding:
   mode: huggingface
 
 huggingface:
-  embedding_hf_model_name: BAAI/bge-small-en-v1.5
+  embedding_hf_model_name: nomic-ai/nomic-embed-text-v1.5
 
 vectorstore:
   database: qdrant

--- a/settings-vllm.yaml
+++ b/settings-vllm.yaml
@@ -12,7 +12,7 @@ embedding:
   ingest_mode: simple
 
 huggingface:
-  embedding_hf_model_name: BAAI/bge-small-en-v1.5
+  embedding_hf_model_name: nomic-ai/nomic-embed-text-v1.5
 
 openai:
   api_base: http://localhost:8000/v1

--- a/settings.yaml
+++ b/settings.yaml
@@ -73,10 +73,10 @@ embedding:
   # Should be matching the value above in most cases
   mode: huggingface
   ingest_mode: simple
-  embed_dim: 384 # 384 is for BAAI/bge-small-en-v1.5
+  embed_dim: 768 # 768 is for nomic-ai/nomic-embed-text-v1.5
 
 huggingface:
-  embedding_hf_model_name: BAAI/bge-small-en-v1.5
+  embedding_hf_model_name: nomic-ai/nomic-embed-text-v1.5
   access_token: ${HF_TOKEN:}
 
 vectorstore:


### PR DESCRIPTION
# Description

To reduce the difficulty of switching between different configurations, we will unify all configurations to use [nomic-embed-text](https://huggingface.co/nomic-ai/nomic-embed-text-v1.5 as the default for all models.

This PR 

## Type of Change
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)