### PR TITLE
Fix: Rectify ffmpy poetry config; update version from 0.3.2 to 0.4.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1250,16 +1250,11 @@ standard = ["fastapi", "uvicorn[standard] (>=0.15.0)"]
 name = "ffmpy"
 version = "0.3.2"
 description = "A simple Python wrapper for ffmpeg"
-optional = true
+optional = false
 python-versions = "*"
-files = []
-develop = false
-
-[package.source]
-type = "git"
-url = "https://github.com/EuDs63/ffmpy.git"
-reference = "333a19ee4d21f32537c0508aa1942ef1aa7afe24"
-resolved_reference = "333a19ee4d21f32537c0508aa1942ef1aa7afe24"
+files = [
+    {file = "ffmpy-0.3.2.tar.gz", hash = "sha256:475ebfff1044661b8d969349dbcd2db9bf56d3ee78c0627e324769b49a27a78f"},
+]
 
 [[package]]
 name = "filelock"
@@ -3854,6 +3849,8 @@ files = [
     {file = "orjson-3.10.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:960db0e31c4e52fa0fc3ecbaea5b2d3b58f379e32a95ae6b0ebeaa25b93dfd34"},
     {file = "orjson-3.10.6-cp312-none-win32.whl", hash = "sha256:a6ea7afb5b30b2317e0bee03c8d34c8181bc5a36f2afd4d0952f378972c4efd5"},
     {file = "orjson-3.10.6-cp312-none-win_amd64.whl", hash = "sha256:874ce88264b7e655dde4aeaacdc8fd772a7962faadfb41abe63e2a4861abc3dc"},
+    {file = "orjson-3.10.6-cp313-none-win32.whl", hash = "sha256:efdf2c5cde290ae6b83095f03119bdc00303d7a03b42b16c54517baa3c4ca3d0"},
+    {file = "orjson-3.10.6-cp313-none-win_amd64.whl", hash = "sha256:8e190fe7888e2e4392f52cafb9626113ba135ef53aacc65cd13109eb9746c43e"},
     {file = "orjson-3.10.6-cp38-cp38-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:66680eae4c4e7fc193d91cfc1353ad6d01b4801ae9b5314f17e11ba55e934183"},
     {file = "orjson-3.10.6-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:caff75b425db5ef8e8f23af93c80f072f97b4fb3afd4af44482905c9f588da28"},
     {file = "orjson-3.10.6-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3722fddb821b6036fd2a3c814f6bd9b57a89dc6337b9924ecd614ebce3271394"},
@@ -6693,4 +6690,4 @@ vector-stores-qdrant = ["llama-index-vector-stores-qdrant"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "25abbb45bc462dbf056b83c0925b505ad1232484a18e50f07c5e7f517dd84e6f"
+content-hash = "c2f18983bfea8396e46c1a324c7a549cf52b3f3ec779676b13e664e0357b531c"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1250,7 +1250,7 @@ standard = ["fastapi", "uvicorn[standard] (>=0.15.0)"]
 name = "ffmpy"
 version = "0.3.2"
 description = "A simple Python wrapper for ffmpeg"
-optional = false
+optional = true
 python-versions = "*"
 files = [
     {file = "ffmpy-0.3.2.tar.gz", hash = "sha256:475ebfff1044661b8d969349dbcd2db9bf56d3ee78c0627e324769b49a27a78f"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -1248,12 +1248,13 @@ standard = ["fastapi", "uvicorn[standard] (>=0.15.0)"]
 
 [[package]]
 name = "ffmpy"
-version = "0.3.2"
-description = "A simple Python wrapper for ffmpeg"
+version = "0.4.0"
+description = "A simple Python wrapper for FFmpeg"
 optional = true
-python-versions = "*"
+python-versions = "<4.0.0,>=3.8.1"
 files = [
-    {file = "ffmpy-0.3.2.tar.gz", hash = "sha256:475ebfff1044661b8d969349dbcd2db9bf56d3ee78c0627e324769b49a27a78f"},
+    {file = "ffmpy-0.4.0-py3-none-any.whl", hash = "sha256:39c0f20c5b465e7f8d29a5191f3a7d7675a8c546d9d985de8921151cd9b59e14"},
+    {file = "ffmpy-0.4.0.tar.gz", hash = "sha256:131b57794e802ad555f579007497f7a3d0cab0583d37496c685b8acae4837b1d"},
 ]
 
 [[package]]
@@ -6690,4 +6691,4 @@ vector-stores-qdrant = ["llama-index-vector-stores-qdrant"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "c2f18983bfea8396e46c1a324c7a549cf52b3f3ec779676b13e664e0357b531c"
+content-hash = "2eaa56bf185723ad028f5221675f1ee070bc70ba7d606ebe28dcfe276a3c9dca"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ sentence-transformers = {version ="^3.0.1", optional = true}
 # Optional UI
 gradio = {version ="^4.37.2", optional = true}
 # Fix: https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/16289#issuecomment-2255106490
-ffmpy = "0.3.2"
+ffmpy = "0.4.0"
 
 # Optional Google Gemini dependency
 google-generativeai = {version ="^0.5.4", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ sentence-transformers = {version ="^3.0.1", optional = true}
 
 # Optional UI
 gradio = {version ="^4.37.2", optional = true}
-# Fix: https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/16289#issuecomment-2255106490
 ffmpy = "0.4.0"
 
 # Optional Google Gemini dependency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ sentence-transformers = {version ="^3.0.1", optional = true}
 # Optional UI
 gradio = {version ="^4.37.2", optional = true}
 # Fix: https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/16289#issuecomment-2255106490
-ffmpy = {git = "https://github.com/EuDs63/ffmpy.git", rev = "333a19ee4d21f32537c0508aa1942ef1aa7afe24", optional = true}
+ffmpy = "0.3.2"
 
 # Optional Google Gemini dependency
 google-generativeai = {version ="^0.5.4", optional = true}


### PR DESCRIPTION
# Description

The current `poetry install` is broken for first installers:
![Screenshot 2024-08-18 at 13 56 50](https://github.com/user-attachments/assets/2234db6c-c031-43e5-826b-882e45f86d4f)

The reason:
- https://github.com/EuDs63/ffmpy is no longer the source repo of ffmpy (archived on 30 July 2024)
![Screenshot 2024-08-18 at 13 58 45](https://github.com/user-attachments/assets/7c378f07-5b62-454f-ba23-ec3c168f400e)
No tags available

If you visit https://pypi.org/project/ffmpy/#history, you can see that it points to a new repo: https://github.com/Ch00k/ffmpy

Related Issues:
- https://github.com/zylon-ai/private-gpt/issues/1378
- https://github.com/zylon-ai/private-gpt/issues/1738
- https://github.com/zylon-ai/private-gpt/issues/1795
- https://github.com/zylon-ai/private-gpt/issues/2005
- https://github.com/zylon-ai/private-gpt/issues/2023


## Type of Change

- [x ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I ran the command `poetry add ffmpy@0.3.2`, and poetry installed all packages without any problem.

``` 
Updating dependencies
Resolving dependencies... Downloading https://files.pythonhosted.org/packages/c7/2c/94ed7b91db81d61d7096ac8f2d325ec562fc75e35f3baea8
Resolving dependencies... (32.9s)

Package operations: 97 installs, 2 updates, 0 removals

  - Downgrading cffi (1.17.0 -> 1.16.0)
  - Installing h11 (0.14.0)
  - Installing mdurl (0.1.2)
  - Installing sniffio (1.3.1)
  - Installing typing-extensions (4.12.2)
  - Installing wrapt (1.16.0)
  - Installing annotated-types (0.7.0)
  - Installing anyio (4.4.0)
  - Installing cryptography (3.4.8)
  - Installing deprecated (1.2.14)
  - Installing frozenlist (1.4.1)
  - Installing httpcore (1.0.5)
  - Installing markdown-it-py (3.0.0)
  - Installing multidict (6.0.5)
  - Installing mypy-extensions (1.0.0)
  - Installing pydantic-core (2.20.1)
  - Installing pygments (2.18.0)
  - Installing six (1.16.0)
  - Installing aiosignal (1.3.1)
  - Installing attrs (23.2.0)
  - Installing click (8.1.7)
  - Installing distro (1.9.0)
  - Installing fsspec (2024.6.1)
  - Installing greenlet (3.0.3)
  - Installing httpx (0.27.0)
  - Installing joblib (1.4.2)
  - Installing marshmallow (3.21.3)
  - Installing numpy (1.26.4)
  - Installing pydantic (2.8.2)
  - Installing python-dateutil (2.9.0.post0)
  - Installing pytz (2024.1)
  - Installing pyyaml (6.0.1)
  - Installing regex (2024.7.24)
  - Installing rich (13.7.1)
  - Installing tqdm (4.66.4)
  - Installing typing-inspect (0.9.0)
  - Installing tzdata (2024.1)
  - Installing yarl (1.9.4)
  - Installing aiohttp (3.9.5)
  - Installing dataclasses-json (0.6.7)
  - Installing dirtyjson (1.0.8)
  - Installing dnspython (2.6.1)
  - Installing httptools (0.6.1)
  - Installing huggingface-hub (0.24.3)
  - Installing markupsafe (2.1.5)
  - Installing nest-asyncio (1.6.0)
  - Installing networkx (3.3)
  - Installing nltk (3.8.1)
  - Installing openai (1.37.1)
  - Installing pandas (2.2.2)
  - Installing pillow (10.4.0)
  - Installing python-dotenv (1.0.1)
  - Installing sqlalchemy (2.0.31)
  - Installing tenacity (8.5.0)
  - Installing tiktoken (0.7.0)
  - Installing typer (0.12.3)
  - Installing uvloop (0.19.0)
  - Installing watchfiles (0.22.0)
  - Installing websockets (11.0.3)
  - Installing email-validator (2.2.0)
  - Installing fastapi-cli (0.0.4)
  - Installing jinja2 (3.1.4)
  - Installing llama-index-core (0.10.58)
  - Installing python-multipart (0.0.9)
  - Installing safetensors (0.4.3)
  - Installing starlette (0.37.2)
  - Installing tokenizers (0.19.1)
  - Installing uvicorn (0.30.3)
  - Installing fastapi (0.111.1)
  - Installing iniconfig (2.0.0)
  - Installing orjson (3.10.6)
  - Installing pluggy (1.5.0)
  - Installing soupsieve (2.5)
  - Installing transformers (4.43.3)
  - Installing ujson (5.10.0)
  - Installing beautifulsoup4 (4.12.3)
  - Installing cfgv (3.4.0)
  - Installing coverage (7.6.0)
  - Updating ffmpy (0.3.1 -> 0.4.0)
  - Installing identify (2.6.0)
  - Installing itsdangerous (2.2.0)
  - Installing nodeenv (1.9.1)
  - Installing pathspec (0.12.1)
  - Installing pydantic-extra-types (2.9.0)
  - Installing pydantic-settings (2.3.4)
  - Installing pypdf (4.3.1)
  - Installing pytest (7.4.4)
  - Installing ruff (0.5.5)
  - Installing striprtf (0.0.26)
  - Installing black (22.12.0)
  - Installing docx2txt (0.8)
  - Installing injector (0.21.0)
  - Installing llama-index-readers-file (0.1.31)
  - Installing mypy (1.11.0)
  - Installing pre-commit (2.21.0)
  - Installing pytest-asyncio (0.21.2)
  - Installing pytest-cov (3.0.0)
  - Installing types-pyyaml (6.0.12.20240724)
  - Installing watchdog (4.0.1)

Writing lock file
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I ran `make check; make test` to ensure mypy and tests pass
![Screenshot 2024-08-18 at 14 31 15](https://github.com/user-attachments/assets/1b655e24-1ca5-473a-88d5-0bf43e94f646)

