### PR TITLE
Sanitize null bytes before ingestion

### DIFF
--- a/private_gpt/components/ingest/ingest_helper.py
+++ b/private_gpt/components/ingest/ingest_helper.py
@@ -94,6 +94,7 @@ class IngestionHelper:
         logger.debug("Specific reader found for extension=%s", extension)
         documents = reader_cls().load_data(file_data)
 
+        # Sanitize NUL bytes in text which can't be stored in Postgres
         for i in range(len(documents)):
             documents[i].text = documents[i].text.replace("\u0000", "")
 

--- a/private_gpt/components/ingest/ingest_helper.py
+++ b/private_gpt/components/ingest/ingest_helper.py
@@ -92,7 +92,12 @@ class IngestionHelper:
             return string_reader.load_data([file_data.read_text()])
 
         logger.debug("Specific reader found for extension=%s", extension)
-        return reader_cls().load_data(file_data)
+        documents = reader_cls().load_data(file_data)
+
+        for i in range(len(documents)):
+            documents[i].text = documents[i].text.replace("\u0000", "")
+
+        return documents
 
     @staticmethod
     def _exclude_metadata(documents: list[Document]) -> None:


### PR DESCRIPTION
# Description

When ingesting documents using Postgres some PDF documents could cause `ValueError: A string literal cannot contain NUL (0x00) characters.`. This PR replaces all null bytes before ingesting the documents to make sure this error doesn't happen.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I ran the pgpt server locally using Ollama and Postgers as both the vector and node store. Before the fix document was not injected, and after adding the sanitization the PDF was successfully ingested and stored.

- [x] I stared at the code and made sure it makes sense

**Test Configuration**:
* Hardware: MacbookPro M2Pro
* Toolchain: Ollama, Postgres

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran `make check; make test` to ensure mypy and tests pass