### PR TITLE
fix(tabular): force-close sandbox after analysis to avoid leaks

### DIFF
--- a/private_gpt/components/sandbox/base.py
+++ b/private_gpt/components/sandbox/base.py
@@ -137,8 +137,13 @@ class SandboxSession(ABC):
         return None
 
     @abstractmethod
-    async def close(self) -> None:
-        """Release resources."""
+    async def close(self, force: bool = False) -> None:
+        """Release resources.
+
+        ``force=True`` also releases the backend resource instead of leaving
+        it available for reuse (e.g. kills an OpenSandbox container). Backends
+        that never pool/reuse sessions may ignore the flag.
+        """
 
 
 class SandboxProvider(ABC):

--- a/private_gpt/components/sandbox/local.py
+++ b/private_gpt/components/sandbox/local.py
@@ -112,7 +112,8 @@ class BashExecutorSandbox(SandboxSession):
         real = self._translator.to_real(path)
         await anyio.to_thread.run_sync(lambda: real.chmod(mode))
 
-    async def close(self) -> None:
+    async def close(self, force: bool = False) -> None:
+        del force  # local sessions are not pooled; close is always final
         pass
 
 
@@ -129,7 +130,8 @@ class LocalSandboxSession(BashExecutorSandbox):
         super().__init__(mounts, executor, env=env)
         self._workdir = workdir
 
-    async def close(self) -> None:
+    async def close(self, force: bool = False) -> None:
+        del force  # local sessions are not pooled; close is always final
         await anyio.to_thread.run_sync(
             lambda: shutil.rmtree(self._workdir, ignore_errors=True)
         )

--- a/private_gpt/components/tabular/pandasai_sandbox.py
+++ b/private_gpt/components/tabular/pandasai_sandbox.py
@@ -175,7 +175,7 @@ class PandasAISandboxAdapter(Sandbox):  # type: ignore[misc]
 
         try:
             if self._client:
-                self._run(self._client.close())
+                self._run(self._client.close(force=True))
             if self._temp_dir and self._temp_dir.exists():
                 shutil.rmtree(self._temp_dir, ignore_errors=True)
         except Exception as e:

--- a/private_gpt/components/tabular/pandasai_service.py
+++ b/private_gpt/components/tabular/pandasai_service.py
@@ -346,4 +346,4 @@ class PandasAIService(BaseModel):
             return result
         finally:
             if sandbox is not None:
-                await asyncio.to_thread(sandbox.stop)
+                await asyncio.shield(asyncio.to_thread(sandbox.stop))

--- a/private_gpt/components/tabular/pandasai_service.py
+++ b/private_gpt/components/tabular/pandasai_service.py
@@ -332,17 +332,18 @@ class PandasAIService(BaseModel):
             + (f" over sandbox: {sandbox.__class__.__name__}" if sandbox else "")
         )
 
-        result = await asyncio.to_thread(
-            self._run_analysis_sync, query, smart_dataframes, sandbox
-        )
+        try:
+            result = await asyncio.to_thread(
+                self._run_analysis_sync, query, smart_dataframes, sandbox
+            )
 
-        logger.debug(
-            f"Result: {result.response} "
-            f"Type: {type(result.response)} "
-            f"Last code executed: {result.response.last_code_executed}"
-        )
+            logger.debug(
+                f"Result: {result.response} "
+                f"Type: {type(result.response)} "
+                f"Last code executed: {result.response.last_code_executed}"
+            )
 
-        if sandbox is not None:
-            await asyncio.to_thread(sandbox.stop)
-
-        return result
+            return result
+        finally:
+            if sandbox is not None:
+                await asyncio.to_thread(sandbox.stop)


### PR DESCRIPTION
PandasAISandboxAdapter.stop() now closes the wrapped session with force=True so one-shot tabular sandboxes are released on remote backends (e.g. OpenSandbox) instead of lingering until their TTL. run_analysis guarantees stop() in a finally, so cleanup happens even on analysis errors. SandboxSession.close() accepts a force flag (default False); local sessions ignore it.