### PR TITLE
docs: fix stale docstrings in document expander and memory strategy factory

### DIFF
--- a/private_gpt/components/chat/processors/chat_history/memory/strategies/base_strategy.py
+++ b/private_gpt/components/chat/processors/chat_history/memory/strategies/base_strategy.py
@@ -84,15 +84,15 @@ def get_condense_memory_strategy(
     injector: Injector | None = None,
     **kwargs: Any,
 ) -> BaseMemoryStrategy:
-    """Get the condense strategy from a string or CondenseStrategy enum.
+    """Get the memory strategy matching the given CondenseStrategyType.
 
     Args:
-        strategy (str | CondenseStrategy): The strategy to get.
+        strategy (str | CondenseStrategyType): The strategy to get.
         injector (Injector | None): Optional dependency injector for workflow builders.
         **kwargs: Additional keyword arguments to pass to the strategy constructor.
 
     Returns:
-        CondenseStrategy: The corresponding CondenseStrategy enum.
+        BaseMemoryStrategy: The strategy instance for the given type.
     """
     strategy_enum = (
         strategy

--- a/private_gpt/components/postprocessor/tree_expansion/document_expander.py
+++ b/private_gpt/components/postprocessor/tree_expansion/document_expander.py
@@ -112,11 +112,10 @@ class DocumentTreeExpander:
         return self.result_nodes_ids, token_count
 
     def _get_token_count_by_id(self, node_id: str) -> int | None:
-        """Calculate the token count of a node and its subtree (if applicable).
+        """Get the cached token count of a node.
 
         Args:
-            node_id: The node ID to count tokens for
-            include_subtree: Whether to include tokens from all descendant nodes
+            node_id: The node ID to look up
 
         Returns:
             Total token count


### PR DESCRIPTION
Two docstring accuracy fixes, each verified against the signature:

1. `document_expander._get_token_count_by_id(node_id)` documented an `include_subtree` parameter and a subtree-summing description, copied from the adjacent `_get_token_count`; it is a plain cache lookup that can return `None`. Reworded to match.
2. `base_strategy.get_condense_memory_strategy` referenced a `CondenseStrategy` enum that does not exist anywhere in the codebase (the actual type is `CondenseStrategyType`, used correctly in the body) and claimed an enum return; the function returns a `BaseMemoryStrategy`. Fixed both.