### PR TITLE
docs: fix private_pgt typo in settings.yaml comment

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -1,6 +1,6 @@
 # The default configuration file.
 # More information about configuration can be found in the documentation: https://docs.privategpt.dev/
-# Syntax in `private_pgt/settings/settings.py`
+# Syntax in `private_gpt/settings/settings.py`
 server:
   env_name: ${APP_ENV:prod}
   root_path: ${PGPT_ROOT_PATH:}


### PR DESCRIPTION
The shipped default config's header comment references `private_pgt/settings/settings.py` — the package is `private_gpt` (only occurrence of the typo in the repo).